### PR TITLE
When f5_global_routed_mode is False, the advertised_tunnel_types must be provided

### DIFF
--- a/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
+++ b/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
@@ -24,7 +24,7 @@
     section: DEFAULT
     option: f5_vtep_selfip_name
     value: selfip.client
-  when: '{{ f5_global_routed_mode }}'
+  when: not {{ f5_global_routed_mode }}
 
 - name: Configure F5 OpenStack LBaaSv2 Agent set advertised tunnel types for undercloud
   ini_file:
@@ -32,7 +32,7 @@
     section: DEFAULT
     option: advertised_tunnel_types
     value: '{{ advertised_tunnel_types }}'
-  when: '{{ f5_global_routed_mode }}'
+  when: not {{ f5_global_routed_mode }}
 
 - name: Configure F5 OpenStack LBaaSv2 Agent with icontrol_hostname
   ini_file:


### PR DESCRIPTION
Issues:
Fixes #2

Problem:
The setting for f5_global_routed_mode was recently introduced and used
in a different manner than undercloud/overcloud. We ned to adjust the
boolean checks for 'when' to make changes in the agent.

Analysis:
Flipped the appropriate logic in the configuration for the agent.

Tests: