### PR TITLE
Barbican service setup needed in agent configuration role

### DIFF
--- a/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
+++ b/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
@@ -41,6 +41,14 @@
     option: icontrol_hostname
     value: '{{ bigip_netloc }}'
 
+- name: Configure F5 OpenStack LBaaSv2 Agent with Barbican as cert manager
+  ini_file:
+    dest: '{{ agent_ini_file }}'
+    section: DEFAULT
+    option: cert_manager
+    value: f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+  when: "{{ use_barbican_cert_manager }}"
+
 - name: Stop F5 OpenStack Agent in prep for restarting
   service:
     name: '{{ agent_service_name }}'

--- a/playbooks/roles/configure_lbaasv2_agent/vars/main.yml
+++ b/playbooks/roles/configure_lbaasv2_agent/vars/main.yml
@@ -1,0 +1,2 @@
+---
+use_barbican_cert_manager: False

--- a/playbooks/vars/agent_configuration_vars.yaml
+++ b/playbooks/vars/agent_configuration_vars.yaml
@@ -3,4 +3,5 @@ bigip_netloc: <bigip_ip_address_or_hostname>
 agent_ini_file: /etc/neutron/services/f5/f5-openstack-agent.ini
 f5_global_routed_mode: <True_or_False>     # Set to True or False
 advertised_tunnel_types: <tunnel_type>     # vxlan, gre etc...
+use_barbican_cert_manager: <True_or_False> # False by default. Set to True if using barbican for certs and keys
 remote_user: <remote_username>             # User ansible will use to issue commands


### PR DESCRIPTION
@szakeri 

#### What issues does this address?
Fixes #5 

#### What's this change do?
Modified the configure_lbaasv2_agent role task to add the barbican
service to the agent's ini file when configuring the agent.

#### Where should the reviewer start?

#### Any background context?
For installing and configuring the agent, we often need to setup
barbican as the certificate manager. This functionality needs to be
added in the agent configuration role.