### PR TITLE
Make agent installation perform an optional upgrade when using pip

### DIFF
--- a/playbooks/roles/install_lbaasv2_agent/tasks/main.yml
+++ b/playbooks/roles/install_lbaasv2_agent/tasks/main.yml
@@ -18,9 +18,15 @@
     state: present
   when: not use_pip|bool
 
-- name: Install the F5 OpenStack LBaaSv2 Agent
+- name: Install the F5 OpenStack LBaaSv2 Agent with pip
+  pip:
+    name: '{{ agent_pkg_location }}'
+    editable: false
+  when: use_pip|bool and not pip_upgrade|bool
+
+- name: Upgrade the F5 OpenStack LBaaSv2 Agent with pip
   pip:
     name: '{{ agent_pkg_location }}'
     editable: false
     extra_args: --upgrade
-  when: use_pip|bool
+  when: use_pip|bool and pip_upgrade|bool

--- a/playbooks/roles/install_lbaasv2_agent/vars/main.yml
+++ b/playbooks/roles/install_lbaasv2_agent/vars/main.yml
@@ -1,0 +1,2 @@
+---
+pip_upgrade: False

--- a/playbooks/roles/install_lbaasv2_driver/tasks/main.yml
+++ b/playbooks/roles/install_lbaasv2_driver/tasks/main.yml
@@ -15,19 +15,13 @@
     url: '{{ neutron_lbaas_init_location }}'
     dest: '{{ neutron_lbaas_shim_install_dest }}'
 
-- name: Install the LBaaSv2 Driver from an rpm package
+- name: Install the LBaaSv2 Driver from an rpm or deb package
   package:
     name: '{{ driver_pkg_location }}'
     state: present
   when: not use_pip|bool
 
-- name: Install the LBaaSv2 Driver from an rpm package
-  package:
-    name: '{{ driver_pkg_location }}'
-    state: present
-  when: not use_pip|bool
-
-- name: Install the F5 OpenStack LBaaSv2 Driver
+- name: Install the F5 OpenStack LBaaSv2 Driver with pip
   pip:
     name: '{{ driver_pkg_location }}'
     editable: false

--- a/playbooks/vars/agent_deploy_vars.yaml
+++ b/playbooks/vars/agent_deploy_vars.yaml
@@ -4,9 +4,9 @@ use_pip: True
 
 
 # Provide the locations of the agent packages to install
-#   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-agent.git@v9.1.0
-#         Or you can provide the PyPi package name and version, such as: f5-openstack-agent==v9.1.0
-agent_pkg_location: f5-openstack-agent==9.1.0  # Ex: f5-openstack-agent==9.1.0 or git+https://github.com/F5Networks/f5-openstack-agent.git@mitaka
+#   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-agent.git@v8.3.0
+#         Or you can provide the PyPi package name and version, such as: f5-openstack-agent==v8.3.0
+agent_pkg_location: f5-openstack-agent==8.3.0  # Ex: f5-openstack-agent==9.1.0 or git+https://github.com/F5Networks/f5-openstack-agent.git@liberty
 
 # If using deb or rpm pacakges, here you must also provide locations of icontrol_rest and f5-sdk packages
 f5_icontrol_rest_python_pkg_location: <f5_icontrol_rest_python_pkg_location> # https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.0.9/f5-icontrol-rest-1.0.9-1.el7.noarch.rpm

--- a/playbooks/vars/agent_driver_deploy_vars.yaml
+++ b/playbooks/vars/agent_driver_deploy_vars.yaml
@@ -1,18 +1,19 @@
-# If using pip to install the agent or driver packages, set variable 'use_pip: true'
+# If using pip to install the agent or driver packages, set variable 'use_pip: True'
 # If using deb or rpm packages, set 'use_pip: false'
 use_pip: True
-
+# Optionally perform a pip upgrade
+# pip_upgrade: True
 
 # Provide the locations of the agent, driver, and neutron-lbaas packages to install
-#   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-agent.git@v9.1.0
-#         Or you can provide the PyPi package name and version, such as: f5-openstack-agent==v9.1.0
-agent_pkg_location: <pip_pkg_location>  # Ex: f5-openstack-agent==9.1.0 or git+https://github.com/F5Networks/f5-openstack-agent.git@mitaka
-driver_pkg_location: <pip_pkg_location> # Ex: f5-openstack-lbaasv2-driver or git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@mitaka
+#   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-agent.git@v8.3.0
+#         Or you can provide the PyPi package name and version, such as: f5-openstack-agent==v8.3.0
+agent_pkg_location: <pip_pkg_location>  # Ex: f5-openstack-agent==8.3.0 or git+https://github.com/F5Networks/f5-openstack-agent.git@liberty
+driver_pkg_location: <pip_pkg_location> # Ex: f5-openstack-lbaasv2-driver or git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
 
 
 # Links to the F5 Networks neutron-lbaas driver and __init__.py
-neutron_lbaas_driver_location: <driver_v2.py_file_location> # https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v9.1.0/neutron_lbaas/drivers/f5/driver_v2.py
-neutron_lbaas_init_location: <__init__.py_file_location>    # https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v9.1.0/neutron_lbaas/drivers/f5/__init__.py
+neutron_lbaas_driver_location: <driver_v2.py_file_location> # https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v8.0.1/neutron_lbaas/drivers/f5/driver_v2.py
+neutron_lbaas_init_location: <__init__.py_file_location>    # https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v8.0.1/neutron_lbaas/drivers/f5/__init__.py
 
 
 # If using deb or rpm pacakges, here you must also provide locations of icontrol_rest and f5-sdk packages

--- a/playbooks/vars/driver_deploy_vars.yaml
+++ b/playbooks/vars/driver_deploy_vars.yaml
@@ -4,14 +4,14 @@ use_pip: True
 
 
 # Provide the location of the driver and neutron-lbaas packages to install
-#   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@v9.1.0
-#         Or you can provide the PyPi package name and version, such as: f5-openstack-lbaasv2-driver==v9.1.0
-driver_pkg_location: f5-openstack-lbaasv2-driver==9.1.0 # Ex: f5-openstack-lbaasv2-driver or git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@mitaka
+#   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@v8.3.0
+#         Or you can provide the PyPi package name and version, such as: f5-openstack-lbaasv2-driver==v8.3.0
+driver_pkg_location: f5-openstack-lbaasv2-driver==8.3.0 # Ex: f5-openstack-lbaasv2-driver or git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
 
 
 # Links to the F5 Networks neutron-lbaas driver and __init__.py
-neutron_lbaas_driver_location: https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v9.1.0/neutron_lbaas/drivers/f5/driver_v2.py
-neutron_lbaas_init_location: https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v9.1.0/neutron_lbaas/drivers/f5/__init__.py
+neutron_lbaas_driver_location: https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v8.0.1/neutron_lbaas/drivers/f5/driver_v2.py
+neutron_lbaas_init_location: https://raw.githubusercontent.com/F5Networks/neutron-lbaas/v8.0.1/neutron_lbaas/drivers/f5/__init__.py
 
 # The following variables are used for configuring the driver
 neutron_lbaas_shim_install_dest: /usr/lib/python2.7/site-packages/neutron_lbaas/drivers/f5


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #16 and #4 

#### What's this change do?
Added a default pip_upgrade variable and set it to 'False'. Set a new
condition for when use_pip and the pip_upgrade are set to 'True'.

There are some other documentation and naming issues I fixed here as well.

#### Where should the reviewer start?

#### Any background context?
When the agent is installed, we perform an upgrade with pip. This has a
side-effect of upgrading dependencies to the latest versions, even if it
is strictly not necessary for testing. We should be able to optionally
upgrade with pip, but the default behavior will be to not upgrade.

Ran deployment on existing liberty stack.

```
[testlab@host-168 ~(keystone_testlab)]$ glance image-list
+--------------------------------------+------------------------------------------+
| ID                                   | Name                                     |
+--------------------------------------+------------------------------------------+
| 5c0f23e3-5b77-4b36-9cf7-8860a80125b9 | BIGIP-11.6.0.LTM.Tiny.qcow2              |
| 182ed7e5-7767-4366-9ec3-5f87c7204ad5 | CentOS-7-x86_64-GenericCloud.qcow2       |
| def9a92f-80ef-4ca7-a196-2ad6bb221b1d | cirros-0.3.4-x86_64-disk.qcow2           |
| cccc8bc4-49e6-45a4-80da-6b50ea617588 | cluster_ready-BIGIP-11.6.0.0.0.401.qcow2 |
| 5450c8bd-00be-4a1d-8de0-f20cb2890bdd | os_ready-BIGIP-11.5.4.2.0.291.qcow2      |
| c7151f01-0947-4ddf-8041-007383851a4d | os_ready-BIGIP-11.6.0.0.0.401.ALL.qcow2  |
| 93469dc0-832b-4fd6-9a82-4da6f73d099c | os_ready-BIGIP-11.6.0.0.0.401.qcow2      |
| c6e68f7c-6a23-4b21-878d-a7edc5515b1f | os_ready-BIGIP-11.6.1.1.0.326.qcow2      |
| e2367af9-136f-44f9-9507-4d8b5f31aaf9 | os_ready-BIGIP-12.0.0.4.0.674.qcow2      |
| 4f20dfbb-82dd-4d39-b006-ad0a033fd16c | os_ready-BIGIP-12.1.0.0.0.1434.qcow2     |
| 89e6cd72-dc7c-4ca8-9cd3-9921e1120bb6 | os_ready-BIGIP-12.1.1.2.0.204.qcow2      |
| 35b02104-58f2-4baf-93a8-4fca838cddad | os_ready-BIGIP-13.0.0.0.0.1645.qcow2     |
| 3ef2f2c2-c276-4d53-ab3d-c6c27bb13403 | ubuntu_14.04_lts.qcow2                   |
+--------------------------------------+------------------------------------------+
[testlab@host-168 ~(keystone_testlab)]$
````