### PR TITLE
Need support for setting HA type in OpenStack agent

### DIFF
--- a/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
+++ b/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
@@ -74,4 +74,4 @@
     dest: '{{ agent_ini_file }}'
     section: DEFAULT
     option: f5_ha_type
-    value: '{{ ha_type | default('standalone') }}'
+    value: '{{ ha_type | default("standalone") }}'

--- a/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
+++ b/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
@@ -74,4 +74,4 @@
     dest: '{{ agent_ini_file }}'
     section: DEFAULT
     option: f5_ha_type
-    value: '{{ ha_type | default("standalone") }}'
+    value: '{{ f5_ha_type | default("standalone") }}'

--- a/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
+++ b/playbooks/roles/configure_lbaasv2_agent/tasks/main.yml
@@ -68,3 +68,10 @@
   service:
     name: '{{ agent_service_name }}'
     state: started
+
+- name: Configure F5 OpenStack LBaaSv2 Agent HA type
+  ini_file:
+    dest: '{{ agent_ini_file }}'
+    section: DEFAULT
+    option: f5_ha_type
+    value: '{{ ha_type | default('standalone') }}'

--- a/playbooks/vars/agent_deploy_vars.yaml
+++ b/playbooks/vars/agent_deploy_vars.yaml
@@ -20,6 +20,12 @@ agent_ini_file: /etc/neutron/services/f5/f5-openstack-agent.ini
 # Set advertised tunnel types, if needed
 advertised_tunnel_types: vxlan
 
+# Set f5_ha_type if needed. Defaults to standalone, but can be one of the following:
+#   standalone - single device no HA
+#   pair - active/standby two device HA
+#   scalen - active device cluster
+# f5_ha_type: <standalone | pair | scalen>
+
 # The following var is set according to the CentOS service name
 # Modify to suit the service name on your deployment
 agent_service_name: f5-openstack-agent

--- a/playbooks/vars/agent_driver_deploy_vars.yaml
+++ b/playbooks/vars/agent_driver_deploy_vars.yaml
@@ -29,6 +29,12 @@ neutron_lbaas_shim_install_dest: <neutron_lbaas_shim_install_dest> # Remote loca
 # Set advertised tunnel types, if needed
 # advertised_tunnel_types: <tunnel_type>                           # vxlan, gre
 
+# Set f5_ha_type if needed. Defaults to standalone, but can be one of the following:
+#   standalone - single device no HA
+#   pair - active/standby two device HA
+#   scalen - active device cluster
+# f5_ha_type: <standalone | pair | scalen>
+
 # Set to true only if the services below exist on the node this playbook is deployed
 restart_all_neutron_services: False
 


### PR DESCRIPTION

#### What's this change do?
Adds support for setting f5_ha_type in f5-openstack-agent.ini file.

#### Where should the reviewer start?
playbooks/roles/configure_lbaasv2_agent/tasks/main.yml

#### Any background context?
Change needed to support configuring  BIG-IP clusters.