### PR TITLE
Make git a dependency of each role

### DIFF
--- a/playbooks/roles/f5_ansible_prepare_host/tasks/main.yml
+++ b/playbooks/roles/f5_ansible_prepare_host/tasks/main.yml
@@ -1,0 +1,7 @@
+# version: 2017-08-31
+---
+- name: Install git.
+  package:
+      name: '{{ git_package }}'
+      state: present
+  when: use_pip|bool

--- a/playbooks/roles/install_f5_heat_plugins/meta/main.yml
+++ b/playbooks/roles/install_f5_heat_plugins/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: f5_ansible_prepare_host }

--- a/playbooks/roles/install_lbaasv2_agent/meta/main.yml
+++ b/playbooks/roles/install_lbaasv2_agent/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: f5_ansible_prepare_host }

--- a/playbooks/roles/install_lbaasv2_driver/meta/main.yml
+++ b/playbooks/roles/install_lbaasv2_driver/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: f5_ansible_prepare_host }

--- a/playbooks/roles/install_lbaasv2_driver/tasks/main.yml
+++ b/playbooks/roles/install_lbaasv2_driver/tasks/main.yml
@@ -1,10 +1,5 @@
 # version: 2017-04-20
 ---
-- name: Install git on the node that the driver will be installed on.
-  package:
-      name: '{{ git_package }}'
-      state: present
-
 - name: Create f5 directory in neutron-lbaas install location, if necessary
   file:
     path: '{{ neutron_lbaas_shim_install_dest }}'

--- a/playbooks/vars/agent_deploy_vars.yaml
+++ b/playbooks/vars/agent_deploy_vars.yaml
@@ -2,6 +2,8 @@
 # If using deb or rpm packages, set 'use_pip: false'
 use_pip: True
 
+# Prerequisite for the pip install
+git_package: git
 
 # Provide the locations of the agent packages to install
 #   Note: If using pip, you can provide a link such as: git+https://github.com/F5Networks/f5-openstack-agent.git@v9.3.0

--- a/playbooks/vars/agent_driver_deploy_vars.yaml
+++ b/playbooks/vars/agent_driver_deploy_vars.yaml
@@ -4,7 +4,7 @@ use_pip: True
 # Optionally perform a pip upgrade
 # pip_upgrade: True
 
-# Install git on the node that will have the driver installed on it.
+# Prerequisite for the pip install
 git_package: git
 
 # Provide the locations of the agent, driver, and neutron-lbaas packages to install

--- a/playbooks/vars/driver_deploy_vars.yaml
+++ b/playbooks/vars/driver_deploy_vars.yaml
@@ -2,9 +2,7 @@
 # If using deb or rpm packages, set 'use_pip: false'
 use_pip: True
 
-
-# Provide git early on:
-
+# Prerequisite for the pip install
 git_package: git
 
 # Provide the location of the driver and neutron-lbaas packages to install

--- a/playbooks/vars/heat_plugins_deploy_vars.yaml
+++ b/playbooks/vars/heat_plugins_deploy_vars.yaml
@@ -1,6 +1,12 @@
 # Enter remote user
 remote_user: <remote_username>  # User ansible will use to issue commands
 
+# Pip is currently the only way to install the heat plugins
+use_pip: True
+
+# Prerequisite for the pip install
+git_package: git
+
 # Enter the location for the plugins package
 heat_plugins_pkg_location: <f5_heat_plugins_pkg_location> # Ex: git+https://github.com/F5Networks/f5-openstack-heat-plugins.git@mitaka
 


### PR DESCRIPTION
@jlongstaf @zancas 
#### What issues does this address?
Fixes #30 

#### What's this change do?
Added a new role, f5_ansible_prepare_host, which functions as a dependency for
each role while requires it.

#### Where should the reviewer start?

#### Any background context?
Git must be installed as a dependency of each role where we use pip to install
f5 code. This is because pip often installs from the github repository. We can
add a set of preparatory steps, such as installing git, where we can collect
such tasks as dependencies.

Tested in the test Jenkins build.

http://10.190.25.149:49001/job/devs/job/ha-11.6.1-overcloud/20/consoleFull