### PR TITLE
Create playbook to install ml2 mechanism driver

### DIFF
--- a/playbooks/ml2_driver_deploy.yaml
+++ b/playbooks/ml2_driver_deploy.yaml
@@ -1,0 +1,11 @@
+---
+# version: 2017-09-20
+- hosts: all
+  vars_files:
+    - vars/ml2_driver_deploy_vars.yaml
+  become_user: root
+  become_method: sudo
+  become: true
+  remote_user: '{{ remote_user }}'
+  roles:
+    - role: install_f5_ml2_driver

--- a/playbooks/roles/install_f5_ml2_driver/tasks/main.yml
+++ b/playbooks/roles/install_f5_ml2_driver/tasks/main.yml
@@ -1,0 +1,25 @@
+# version: 2017-09-20
+---
+- name: Install the F5 OpenStack ML2 Mechanism Driver with pip
+  pip:
+    name: '{{ f5_ml2_driver_pkg_location }}'
+    editable: false
+
+- name: Configure Neutron to load F5 OpenStack ML2 Mechanism Driver
+  ini_file:
+    dest: '{{ neutron_entrypoint_file }}'
+    section: neutron.ml2.mechanism_drivers
+    option: f5ml2
+    value: networking_f5.plugins.ml2.drivers.f5.mech_f5networks_bigip:F5NetworksMechanismDriver
+
+- name: Configure ML2 plugin to use F5 OpenStack ML2 Mechanism Driver
+  ini_file:
+    dest: '{{ ml2_conf_file }}'
+    section: ml2
+    option: mechanism_drivers
+    value: openvswitch,f5ml2
+
+- name: Restart Neutron
+  service:
+    name: '{{ neutron_server_service_name }}'
+    state: restarted

--- a/playbooks/vars/ml2_driver_deploy_vars.yaml
+++ b/playbooks/vars/ml2_driver_deploy_vars.yaml
@@ -1,0 +1,12 @@
+# Install F5 OpenStack ML2 Mechanism Driver using pip and restart neutron server
+remote_user: <remote_username> # User ansible will use to issue commands
+
+f5_ml2_driver_pkg_location: git+https://github.com/F5Networks/f5-openstack-ml2-driver.git@stable/mitaka
+neutron_server_service_name:  neutron-server
+
+# This is the specific location of the entrypoints file on the remote server. It is dependent upon
+# the OS and the neutron version you are using, as well as the Python version.
+neutron_entrypoint_file: /usr/lib/python2.7/site-packages/neutron-8.3.0-py2.7.egg-info/entry_points.txt
+
+# The following vars are set by default in the role
+ml2_conf_file: /etc/neutron/plugins/ml2/ml2_conf.ini


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #33 

#### What's this change do?
Created the playbook for installing the ml2 driver and the vars file.

#### Where should the reviewer start?

#### Any background context?
We need to be able to install the f5 ml2 mechanism driver on a node that
contains neutron. This can be done with a single role, to pip install
the library, configure neutron, and restart the neutron server.

Test results will be reflected here, once the driver changes are completed. Do not close until the driver tests have been run.