### PR TITLE
In ml2 playbook vars file, update ml2 branch to be stable/newton instead of stable/mitaka

### DIFF
--- a/playbooks/vars/ml2_driver_deploy_vars.yaml
+++ b/playbooks/vars/ml2_driver_deploy_vars.yaml
@@ -1,7 +1,7 @@
 # Install F5 OpenStack ML2 Mechanism Driver using pip and restart neutron server
 remote_user: <remote_username> # User ansible will use to issue commands
 
-f5_ml2_driver_pkg_location: git+https://github.com/F5Networks/f5-openstack-ml2-driver.git@stable/mitaka
+f5_ml2_driver_pkg_location: git+https://github.com/F5Networks/f5-openstack-ml2-driver.git@stable/newton
 neutron_server_service_name:  neutron-server
 
 # This is the specific location of the entrypoints file on the remote server. It is dependent upon


### PR DESCRIPTION
@richbrowne 

Issues:
Fixes #37

Problem:
In the stable/newton branch of this repo, the stable/mitaka branch is
referenced for the location of the ml2 driver, but it should be changed
to stable/newton, since the two branches will drift quickly in that
repo. These are just default values in variables, but we should modify
it for clarity.

Analysis:
Modified the default variable to point to stable/newton instead of
stable/mitaka.